### PR TITLE
Add two new death statistics

### DIFF
--- a/DeathTrackerModule.cs
+++ b/DeathTrackerModule.cs
@@ -11,6 +11,9 @@ namespace CelesteDeathTracker
     public class DeathTrackerModule : EverestModule
     {
         public static DeathTrackerModule Module;
+        private static DeathDisplay display = null;
+        private static int deathsSinceLevelLoad = 0;
+        private static int deathsSinceTransition = 0;
 
         public DeathTrackerModule()
         {
@@ -20,15 +23,31 @@ namespace CelesteDeathTracker
         public override Type SettingsType => typeof(DeathTrackerSettings);
         public static DeathTrackerSettings Settings => (DeathTrackerSettings) Module._Settings;
 
+        public static void UpdateDisplay(Level level)
+        {
+            var mode = (int)level.Session.Area.Mode;
+            var stats = level.Session.OldStats.Modes[mode];
+
+            display.SetDisplayText(new StringBuilder(Settings.DisplayFormat)
+                .Replace("$C", level.Session.Deaths.ToString())
+                .Replace("$B", stats.SingleRunCompleted ? stats.BestDeaths.ToString() : "-")
+                .Replace("$A", SaveData.Instance.Areas_Safe.First(a => a.ID_Safe == level.Session.Area.ID).Modes[mode].Deaths.ToString())
+                .Replace("$T", SaveData.Instance.TotalDeaths.ToString())
+                .Replace("$L", deathsSinceLevelLoad.ToString())
+                .Replace("$S", deathsSinceTransition.ToString())
+                .ToString());
+        }
+
         public override void Load()
         {
-            DeathDisplay display = null;
             Level level = null;
 
             On.Celeste.LevelLoader.StartLevel += (orig, self) =>
             {
                 level = self.Level;
                 level.Add(display = new DeathDisplay(level));
+                deathsSinceLevelLoad = 0;
+                deathsSinceTransition = 0;
                 orig(self);
             };
             
@@ -36,6 +55,8 @@ namespace CelesteDeathTracker
             {
                 var sessionDeaths = level.Session.Deaths;
                 var stats = level.Session.OldStats.Modes[(int)level.Session.Area.Mode];
+                deathsSinceLevelLoad++;
+                deathsSinceTransition++;
 
                 if (Settings.AutoRestartChapter && stats.SingleRunCompleted && sessionDeaths > 0 &&
                     sessionDeaths >= stats.BestDeaths)
@@ -55,15 +76,13 @@ namespace CelesteDeathTracker
 
             Everest.Events.Player.OnSpawn += player =>
             {
-                var mode = (int) level.Session.Area.Mode;
-                var stats = level.Session.OldStats.Modes[mode];
+                UpdateDisplay(level);
+            };
 
-                display.SetDisplayText(new StringBuilder(Settings.DisplayFormat)
-                    .Replace("$C", level.Session.Deaths.ToString())
-                    .Replace("$B", stats.SingleRunCompleted ? stats.BestDeaths.ToString() : "-")
-                    .Replace("$A", SaveData.Instance.Areas_Safe.First(a => a.ID_Safe == level.Session.Area.ID).Modes[mode].Deaths.ToString())
-                    .Replace("$T", SaveData.Instance.TotalDeaths.ToString())
-                    .ToString());
+            Everest.Events.Level.OnTransitionTo += (lvl, next, direction) =>
+            {
+                deathsSinceTransition = 0;
+                UpdateDisplay(lvl);
             };
         }
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/README.md
+++ b/README.md
@@ -15,4 +15,10 @@ Enter any format you like there. Certain values act as placeholders:
 `$C` - Deaths of the current attempt<br/>
 `$B` - Best (lowest death count) clear<br/>
 `$A` - Total deaths of the current area<br/>
-`$T` - Total deaths of the save file
+`$T` - Total deaths of the save file<br/>
+`$L` - Deaths since the last level load<br/>
+`$S` - Deaths on the current screen (since the last screen transition)<br/>
+
+`$L` and `$S` show deaths for the current gaming session only, so they start at 0 when the game loads.<br/>
+In other words, they help you to keep track of your deaths on this level for the current gaming session (`$L`), or deaths on the current screen for the current gaming session (`$S`).<br/>
+If you switch level (for `$L`) or screen (for `$S`) and come back, they reset to 0.

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 ﻿- Name: DeathTracker
-  Version: 1.0.4
+  Version: 1.1.0
   DLL: CelesteDeathTracker.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
Hi!  
I wanted a mod to track how many times I've died the current gaming session, especially in the current screen/room, i.e. a value that resets to 0 on screen transitions.  
I couldn't find a mod that showed these stats, but this one was close, so I added the functionality.

I don't know if you're interested in adding it to the released mod or not, but I figured I'd open a PR and check!